### PR TITLE
[BE]fix:게시물 생성 시 imagepath가 null이면 생성 불가, 게시물 수정 시 imagepath는 변화있을 때만 업데이트

### DIFF
--- a/server/src/main/java/com/example/group4eaten/post/service/PostService.java
+++ b/server/src/main/java/com/example/group4eaten/post/service/PostService.java
@@ -31,21 +31,16 @@ public class PostService {
         return postRepository.findById(postId).orElse(null);
     }
 
-//    @Transactional
-//    public Post create(PostDto dto){
-//        Post post = dto.toEntity();
-//        if(post.getPostId() != null)
-//            return null;
-//        return postRepository.save(post);
-//    }
-
     //게시물 생성
     @Transactional
     public PostDto create(PostDto dto) {
+        // 이미지 경로가 null이면 생성 불가
+        if (dto.getImagepath() == null) {
+            throw new IllegalArgumentException("Post 생성 실패! 이미지 경로는 null일 수 없습니다.");
+        }
         User user = userRepository.findById(dto.getUserId())
                 .orElseThrow(() -> new IllegalArgumentException("Post 생성 실패! User not found"));
         Post post = Post.createPost(dto, user);
-        //Post post = dto.toEntity(user);
         Post created = postRepository.save(post);
         return PostDto.createPostDto(created);
     }
@@ -56,10 +51,13 @@ public class PostService {
     public PostDto update(Long postId, PostDto dto) {
         Post target = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("Post not found!"));
+        // imagepath에 변화가 있다면 업데이트
+        if (dto.getImagepath() != null && !dto.getImagepath().equals(target.getImagepath())) {
+            target.setImagepath(dto.getImagepath());
+        }
         // dto를 사용하여 target 엔터티를 업데이트
         target.setContent(dto.getContent());
         target.setEdit_YN(dto.getEdit_YN());
-        target.setImagepath(dto.getImagepath());
 
         Post updated = postRepository.save(target);
         return PostDto.createPostDto(updated);


### PR DESCRIPTION
## 개요
fix:게시물 생성 시 imagepath가 null이면 생성 불가, 게시물 수정 시 imagepath는 변화있을 때만 업데이트

## 작업사항
게시물 생성 시 imagepath가 null이면 생성 불가
게시물 수정 시 imagepath는 변화있을 때만 업데이트. null이거나 원래 imagepath 값과 같으면 변화 없음

## 변경로직

- [x] Bug Fix (fix)
- [ ] New Features (feat)
- [ ] Test (test)
- [ ] Document modification (docs)
- [ ] Refactoring (refactor)
- [ ] Styling (style)
- [ ] ETC, No production code change (chore)
- [ ] Build task and Dependency management (build)
