### PR TITLE
[BE] fix:닉네임 중복체크 api 삭제(닉네임 중복 가능)

### DIFF
--- a/server/src/main/java/com/example/group4eaten/user/dto/UserForm.java
+++ b/server/src/main/java/com/example/group4eaten/user/dto/UserForm.java
@@ -2,6 +2,7 @@ package com.example.group4eaten.user.dto;
 
 import com.example.group4eaten.entity.User;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.*;
 
 @Data
@@ -14,6 +15,7 @@ public class UserForm {
     @NotBlank(message = "아이디를 입력해주세요.")
     private String userId;
     @NotBlank(message = "비밀번호를 입력해주세요.")
+    @Size(min = 8, message = "비밀번호는 8자 이상이여야 합니다!")
     private String password;
     @NotBlank(message = "닉네임을 입력해주세요.")
     private String nickname;

--- a/server/src/main/java/com/example/group4eaten/user/service/UserService.java
+++ b/server/src/main/java/com/example/group4eaten/user/service/UserService.java
@@ -52,11 +52,6 @@ public class UserService {
 
         if (userOptional.isPresent()) {
             User user = userOptional.get();
-            // 새로운 닉네임이 다른 사용자와 중복되는지 확인
-            if (isDuplicateNickname(nickname)) {
-                log.error("새로운 닉네임이 이미 존재합니다.");
-                return false; // 중복된 경우 업데이트 실패
-            }
             // 닉네임 업데이트
             user.setNickname(nickname);
 
@@ -66,7 +61,6 @@ public class UserService {
             // 사용자가 존재하지 않을 경우
             return false; // 업데이트 실패
         }
-
     }
 
     public void delete(String userId) {
@@ -82,10 +76,6 @@ public class UserService {
 
     public boolean isDuplicateUserId(String userId) {
         return userRepository.findByUserId(userId).isPresent();
-    }
-
-    public boolean isDuplicateNickname(String nickname) {
-        return userRepository.findByNickname(nickname).isPresent();
     }
 
     public String getNickname(String userId) {


### PR DESCRIPTION
## 개요
fix:닉네임 중복체크 api 삭제(닉네임 중복 가능)

## 작업사항
- 닉네임 중복체크 api 삭제(닉네임 중복 가능)

## 변경로직

- [x] Bug Fix (fix)
- [ ] New Features (feat)
- [ ] Test (test)
- [ ] Document modification (docs)
- [ ] Refactoring (refactor)
- [ ] Styling (style)
- [ ] ETC, No production code change (chore)
- [ ] Build task and Dependency management (build)
