### PR TITLE
[BE]fix: 게시물 수정값이 원래값과 동일하면 edit_YN을 true로 바꾸지 않도록 수정 

### DIFF
--- a/server/src/main/java/com/example/group4eaten/entity/Post.java
+++ b/server/src/main/java/com/example/group4eaten/entity/Post.java
@@ -62,14 +62,14 @@ public class Post {
             throw new IllegalArgumentException("포스트 업데이트 실패! 잘못된 포스트 아이디입니다.");
         }
 
-        // content가 null이 아니면 업데이트
-        if (dto.getContent() != null) {
+        // content가 null이 아니고 원래의 content와 다르다면 업데이트
+        if (dto.getContent() != null && !dto.getContent().equals(this.content)) {
             this.content = dto.getContent();
             this.edit_YN = true; // content가 업데이트되면 edit_YN을 true로 설정
         }
 
-        // imagepath가 null이 아니면 업데이트
-        if (dto.getImagepath() != null) {
+        // imagepath가 null이 아니고 원래의 imagepath와 다르다면 업데이트
+        if (dto.getImagepath() != null && !dto.getImagepath().equals(this.imagepath)) {
             this.imagepath = dto.getImagepath();
             this.edit_YN = true; // imagepath가 업데이트되면 edit_YN을 true로 설정
         }


### PR DESCRIPTION
## 개요
fix: 게시물 수정 시 원래의 content/imagepath 값과 동일하면 edit_YN을 true로 바꾸지 않도록 수정

## 작업사항
PUT /posts 에서 request body로 받은 content와 imagepath가 둘 다 null이거나 원래 값과 동일하면 edit_YN을 true로 바꾸지 않음

## 변경로직

- [x] Bug Fix (fix)
- [ ] New Features (feat)
- [ ] Test (test)
- [ ] Document modification (docs)
- [ ] Refactoring (refactor)
- [ ] Styling (style)
- [ ] ETC, No production code change (chore)
- [ ] Build task and Dependency management (build)
