### PR TITLE
[BE]fix: mypage api sessionId 받아올 수 있게 수정 / feat: 이미지 업로드 api 초안

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -11,6 +11,10 @@ java {
 	sourceCompatibility = '17'
 }
 
+compileJava {
+	options.compilerArgs << '-parameters'
+}
+
 repositories {
 	mavenCentral()
 }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.projectlombok:lombok:1.18.26'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.4'
 
 }
 

--- a/server/src/main/java/com/example/group4eaten/post/api/PostApiController.java
+++ b/server/src/main/java/com/example/group4eaten/post/api/PostApiController.java
@@ -1,8 +1,8 @@
 package com.example.group4eaten.post.api;
 
 import com.example.group4eaten.post.dto.PostDto;
+import com.example.group4eaten.post.repository.PostRepository;
 import com.example.group4eaten.post.service.PostService;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,7 +33,8 @@ public class PostApiController {
     @Value("${upload.path}")
     private String uploadPath;
 
-
+    @Autowired
+    private PostRepository postRepository;
 
     //전체 게시물 조회
     @GetMapping("/posts")
@@ -163,15 +164,13 @@ public class PostApiController {
 
     // 내 페이지 (내가 작성한 게시물 조회 가능)
     @GetMapping("/mypage")
-    public ResponseEntity<List<PostDto>> getmypage(@RequestHeader(name = "sessionId") String sessionId, HttpServletRequest request) {
+    public ResponseEntity<List<PostDto>> getmypage(@RequestHeader(name = "sessionId") String sessionId, HttpSession session) {
         List<PostDto> myPosts;
-
-        // 세션 얻기
-        HttpSession session = request.getSession(false);
-
-        if (session != null && session.getId().equals(sessionId)) {
+        //session을 바로 받아오는 방식 사용
+        if (session != null) {
             // 세션에서 userId 가져오기
             String userId = (String) session.getAttribute("userId");
+            log.info("현재 로그인한 사용자의 id: {}", userId);
 
             // userId를 이용하여 작성된 post들을 가져오는 로직 추가
             myPosts = postService.getMyPosts(userId);

--- a/server/src/main/java/com/example/group4eaten/post/dto/PostDto.java
+++ b/server/src/main/java/com/example/group4eaten/post/dto/PostDto.java
@@ -3,6 +3,7 @@ package com.example.group4eaten.post.dto;
 import com.example.group4eaten.entity.Post;
 import com.example.group4eaten.entity.User;
 import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -21,6 +22,7 @@ public class PostDto {
     private String date;
     private String imagepath;
     private Boolean edit_YN = false;
+    private MultipartFile imageFile;
 
     //게시물 조회할 때 사용 - 기존에 저장된 Post 엔티티를 PostDto로 변환
     public static PostDto createPostDto(Post post) {

--- a/server/src/main/java/com/example/group4eaten/post/repository/PostRepository.java
+++ b/server/src/main/java/com/example/group4eaten/post/repository/PostRepository.java
@@ -6,13 +6,14 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 
 public interface PostRepository extends JpaRepository<Post, Long> {
-    @Query(value = "SELECT *FROM post WHERE userId = :userId", nativeQuery = true)
-    List<Post> findByUserId(String userId);
+    @Query(value = "SELECT * FROM tb_post WHERE user_id = :userId", nativeQuery = true)
+    List<Post> findByUserId(@Param("userId") String userId);
 
     @Query(value = "SELECT p.* FROM tb_like l " +
             "JOIN tb_post p ON l.post_id = p.post_id " +

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -14,3 +14,8 @@ logging.level.org.hibernate.type.descriptor.sql=trace
 
 spring.jpa.hibernate.ddl-auto=create
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
+
+spring.servlet.multipart.enabled=true
+spring.servlet.multipart.max-file-size=200MB
+spring.servlet.multipart.max-request-size=512MB
+upload.path=./uploads

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -10,7 +10,7 @@ spring.jpa.properties.hibernate.show_sql=true
 
 spring.jpa.properties.hibernate.format_sql=true
 
-logging.level.org.hibernate.type.descriptor.sql=trace
+logging.level.org.hibernate.type.descriptor.sql=debug
 
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
@@ -18,4 +18,4 @@ spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 spring.servlet.multipart.enabled=true
 spring.servlet.multipart.max-file-size=200MB
 spring.servlet.multipart.max-request-size=512MB
-upload.path=./uploads
+upload.path=uploads


### PR DESCRIPTION
## 개요
fix: mypage api sessionId 받아올 수 있게 수정 
feat: 이미지 업로드 api 초안

## 작업사항
mypage api 
- build.gradle에 컴파일 옵션 추가해서 컴파일러가 메소드 파라미터의 이름을 유지하도록 수정
- session을 바로 받아오는 방식으로 변경
- PostRepository 쿼리 수정
- PostApiController에 PostRepository 객체 주입

이미지 업로드
- application.properties 수정 - 파일 업로드될 경로 추가, 파일 최대 크기 추가
- 파일 업로드와 관련된 기능들을 사용하기 위해 build.gradle에 해당 라이브러리 추가
- 새 게시물 작성 api 수정 & 이미지 업로드 api 추가 -> 나중에 이미지 업로드 api는 삭제하고 합칠 예정

## 변경로직

- [x] Bug Fix (fix)
- [x] New Features (feat)
- [ ] Test (test)
- [ ] Document modification (docs)
- [ ] Refactoring (refactor)
- [ ] Styling (style)
- [ ] ETC, No production code change (chore)
- [x] Build task and Dependency management (build)
