### PR TITLE
[BE]fix: imagepath를 서버의 파일 시스템에서의 절대 경로 대신 웹 URL로 변경

### DIFF
--- a/server/src/main/java/com/example/group4eaten/WebConfig.java
+++ b/server/src/main/java/com/example/group4eaten/WebConfig.java
@@ -1,0 +1,14 @@
+package com.example.group4eaten;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry){
+        registry.addResourceHandler("/uploads/**")
+                .addResourceLocations("file:///home/ec2-user/uploads/");
+    }
+}


### PR DESCRIPTION
## 개요
imagepath를 서버의 파일 시스템에서의 절대 경로 대신 웹 URL로 변경

## 작업사항
imagepath로 서버의 파일 시스템에서의 절대 경로를 전해주던 걸 웹 url을 전해주도록 변경
(/home/ec2-user/uploads/image.jpg 형식에서 https://eaten-ecc.site/uploads/image.jpg 형식으로)

## 변경로직

- [x] Bug Fix (fix)
- [ ] New Features (feat)
- [ ] Test (test)
- [ ] Document modification (docs)
- [ ] Refactoring (refactor)
- [ ] Styling (style)
- [ ] ETC, No production code change (chore)
- [ ] Build task and Dependency management (build)
